### PR TITLE
Change TypeScript return type to HTMLElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export interface SelectDom {
 		selectors: K,
 		baseElement?: BaseElement
 	): SVGElementTagNameMap[K] | null;
-	<E extends Element = Element>(
+	<E extends HTMLElement = HTMLElement>(
 		selectors: string,
 		baseElement?: BaseElement
 	): E | null;
@@ -24,7 +24,7 @@ export interface SelectDom {
 		selectors: K,
 		baseElement?: BaseElement
 	): boolean;
-	exists<E extends Element = Element>(
+	exists<E extends HTMLElement = HTMLElement>(
 		selectors: string,
 		baseElement?: BaseElement
 	): boolean;
@@ -36,7 +36,7 @@ export interface SelectDom {
 		selectors: K,
 		baseElements?: BaseElements
 	): SVGElementTagNameMap[K][];
-	all<E extends Element = Element>(
+	all<E extends HTMLElement = HTMLElement>(
 		selectors: string,
 		baseElements?: BaseElements
 	): E[];


### PR DESCRIPTION
`Element` is the correct return type, but also pretty useless because each and every `select` still has to include casting:

<!-- The following code block was formatted with Prettier. If this is not desired, please change this comment to `prettier-github disable`. A copy of your original code block is included below in case you want to restore it.
Learn more about Prettier GitHub at https://github.com/jgierer12/prettier-github

select('.something').style.color = 'red';
// TS2339: Property 'style' does not exist on type 'Element'.


select<HTMLElement>('.something').style.color = 'red';
// ok

-->
```ts
select(".something").style.color = "red";
// TS2339: Property 'style' does not exist on type 'Element'.

select<HTMLElement>(".something").style.color = "red";
// ok
```

This PR would fix the most common usage of `select` and leave only `SVGElement`s to be casted, which is much more rare.