### PR TITLE
Replace .npmignore with `files` word

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-test
-test.js
-example
-examples

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.2.1",
   "description": "Extra lightweight DOM selector helper",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "xo && browserify test.js | tape-run"
   },
@@ -22,6 +23,10 @@
     "selector",
     "jquery",
     "alternative"
+  ],
+  "files": [
+    "index.js",
+    "index.d.ts"
   ],
   "xo": {
     "envs": "browser",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "4.2.1",
   "description": "Extra lightweight DOM selector helper",
   "main": "index.js",
-  "types": "index.d.ts",
   "scripts": {
     "test": "xo && browserify test.js | tape-run"
   },


### PR DESCRIPTION
- Delete .npmignore file.
- Add `files` word in package.json, it like whitelist when you npm
publish.
- Add `types` word for type declaration file.

If use existing .npmignore file to run ```npm publish```, it will upload `.travis.yml` file to [npm](https://npmjs.org).
About `files` word to https://docs.npmjs.com/files/package.json#files
![travis-file](https://user-images.githubusercontent.com/32027253/52911081-2108e080-32da-11e9-9d8d-9a3126ab0cc3.PNG)

Feel free to reject this PR if you feel it's not necessary 😊.
