### PR TITLE
Restore IE11 support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,7 +75,13 @@ function selectAll<T>(selectors: any, baseElements: any): T[] {
 
 	// Can be: select.all('selectors') or select.all('selectors', singleElementOrDocument)
 	if (!baseElements || typeof baseElements.querySelectorAll === 'function') {
-		return new Array(...(baseElements || document).querySelectorAll(selectors));
+		const arr: T[] = [];
+		const selected = (baseElements || document).querySelectorAll(selectors);
+		for (let ii = 0; ii < selected.length; ii++) {
+			arr.push(selected[ii]);
+		}
+
+		return arr;
 	}
 
 	const all = [];
@@ -91,6 +97,7 @@ function selectAll<T>(selectors: any, baseElements: any): T[] {
 	all.forEach(function (v) {
 		arr.push(v);
 	});
+
 	return arr;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -75,13 +75,7 @@ function selectAll<T>(selectors: any, baseElements: any): T[] {
 
 	// Can be: select.all('selectors') or select.all('selectors', singleElementOrDocument)
 	if (!baseElements || typeof baseElements.querySelectorAll === 'function') {
-		const arr: T[] = [];
-		const selected = (baseElements || document).querySelectorAll(selectors);
-		for (let ii = 0; ii < selected.length; ii++) {
-			arr.push(selected[ii]);
-		}
-
-		return arr;
+		return Array.apply(null, (baseElements || document).querySelectorAll(selectors));
 	}
 
 	const all = [];


### PR DESCRIPTION
IE does not like much the spread operator. 
Refactored the `selectAll` function to behave correctly.