### PR TITLE
Simplify types

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,5 @@
 import type {ParseSelector} from 'typed-query-selector/parser';
 
-// Default to HTMLElement instead of Element
-type Parse<Selector extends string> =
-	HTMLElement extends ParseSelector<Selector> ?
-		HTMLElement :
-		ParseSelector<Selector>;
-
 // WARNING: Overloads have to repeated in that fashion because the actual function’s signature is discarded; Only the 2 overloads are brought into the .d.ts file. Tests pass because `tsd` reads from this file instead of `.d.ts`
 
 // ParentNode is inherited by Element, Document, DocumentFragment
@@ -21,7 +15,7 @@ function isQueryable(object: BaseElements): object is ParentNode {
  * @param [baseElement]  The element to look inside of
  * @return               The element found, if any
  */
-function select<Selector extends string, TElement extends Element = Parse<Selector>>(
+function select<Selector extends string, TElement extends Element = ParseSelector<Selector, HTMLElement>>(
 	selectors: Selector | Selector[],
 	baseElement?: ParentNode
 ): TElement | undefined;
@@ -46,7 +40,7 @@ function select<TElement extends Element>(
  * @param [baseElement]  The element to look inside of
  * @return               The element found, if any
  */
-function selectLast<Selector extends string, TElement extends Element = Parse<Selector>>(
+function selectLast<Selector extends string, TElement extends Element = ParseSelector<Selector, HTMLElement>>(
 	selectors: Selector | Selector[],
 	baseElement?: ParentNode
 ): TElement | undefined;
@@ -89,7 +83,7 @@ function selectExists(
  * @param [baseElements]  The element or list of elements to look inside of
  * @return                An array of elements found
  */
-function selectAll<Selector extends string, TElement extends Element = Parse<Selector>>(
+function selectAll<Selector extends string, TElement extends Element = ParseSelector<Selector, HTMLElement>>(
 	selectors: Selector | Selector[],
 	baseElements?: BaseElements
 ): TElement[];

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		]
 	},
 	"dependencies": {
-		"typed-query-selector": "^2.2.3"
+		"typed-query-selector": "^2.4.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.8.0",


### PR DESCRIPTION
Since typed-query-selector v2.4.0, we can specify fallback type now, so we don't need to create customized `Parse` type any more.