### PR TITLE
ref: use native Array rather than convert between Set

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -138,17 +138,19 @@ function $$<Selected extends Element>(
 	// Can be: select.all('selectors') or select.all('selectors', singleElementOrDocument)
 	if (!baseElements || isQueryable(baseElements)) {
 		const elements = (baseElements ?? document).querySelectorAll<Selected>(String(selectors));
-		return Array.prototype.slice.call(elements) as Selected[];
+		return Array.from(elements) as Selected[];
 	}
 
-	const elements = new Set<Selected>();
+	const elements = Selected[];
 	for (const baseElement of baseElements) {
 		for (const element of baseElement.querySelectorAll<Selected>(String(selectors))) {
-			elements.add(element);
+			if (!elements.includes(element)) {
+				elements.push(element);
+			}
 		}
 	}
 
-	return [...elements]; // Convert to array
+	return elements;
 }
 
 export {$, $$, lastElement, elementExists, expectElement};


### PR DESCRIPTION
I was looking at the package trying to understand the TS vs JS output and decided to PR this.

`Array.prototype.slice.call` is no longer required since the addition of `Array.from`, which is a bit easier to read and saves a few bytes on the wire to boot.

Using an Array from the start also improves readability (eliminates the need for a comment to describe `[...elements]`) and, depending on which microbenchmarks you trust, has a small perf bump - `Set` is typically slower than `Array`, especially for simple tasks with few elements (i.e. < ~10k - but if someone is selecting _every_ div on a page, they've got other problems), and the conversion between internal storage types also incurs a cost, especially when using `...` due to how it typically forces the copy (I believe `Array.from()` would also work better in this case, though the differences between the two styles may have been optimized away by now).