### PR TITLE
Nicer import syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"type": "module",
 	"exports": {
 		".": "./index.js",
-		"./strict.js": "./strict.js"
+		"./strict": "./strict.js"
 	},
 	"main": "./index.js",
 	"types": "./index.d.ts",


### PR DESCRIPTION
```js
import {$, $optional} from 'select-dom/strict';
```

is far nicer to write