### PR TITLE
Add strict `lastElement`

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import {$, $$, elementExists, lastElement, expectElement} from './index.js';
+import {$, $$, elementExists, lastElement, expectElement, expectLastElement} from './index.js';
 
 // `select-dom` defaults to HTMLElement where possible because it's the most common use case, even if technically this should not be HTMLElement.
 
@@ -26,6 +26,14 @@ expectType<HTMLElement | undefined>(lastElement('.wow'));
 expectType<HTMLAnchorElement | undefined>(lastElement('a.wow'));
 expectType<HTMLBaseElement | undefined>(lastElement('base'));
 expectType<SVGGElement | undefined>(lastElement('g'));
+
+/**
+ * EXPECT LAST
+ */
+expectType<HTMLElement>(expectLastElement('.wow'));
+expectType<HTMLAnchorElement>(expectLastElement('a.wow'));
+expectType<HTMLBaseElement>(expectLastElement('base'));
+expectType<SVGGElement>(expectLastElement('g'));
 
 /**
  * EXISTS

--- a/index.ts
+++ b/index.ts
@@ -229,4 +229,14 @@ function expectLastElement<Selected extends Element>(
 	throw new ElementNotFoundError(`Expected element not found: ${String(selectors)}`);
 }
 
-export {$, $$, lastElement, elementExists, expectElement, expectElements, expectLastElement, countElements};
+export {
+	$,
+	$$,
+	lastElement,
+	elementExists,
+	countElements,
+
+	expectElement,
+	expectElements,
+	expectLastElement,
+};

--- a/index.ts
+++ b/index.ts
@@ -226,7 +226,7 @@ function expectLastElement<Selected extends Element>(
 		return all[all.length - 1]!;
 	}
 
-	throw new ElementNotFoundError(`Expected elements not found: ${String(selectors)}`);
+	throw new ElementNotFoundError(`Expected element not found: ${String(selectors)}`);
 }
 
 export {$, $$, lastElement, elementExists, expectElement, expectElements, expectLastElement, countElements};

--- a/index.ts
+++ b/index.ts
@@ -198,4 +198,35 @@ function expectElements<Selected extends Element>(
 	throw new ElementNotFoundError(`Expected elements not found: ${String(selectors)}`);
 }
 
-export {$, $$, lastElement, elementExists, expectElement, expectElements, countElements};
+/**
+ * @param selectors      One or more CSS selectors separated by commas
+ * @param [baseElement]  The element to look inside of
+ * @return               The element found, or an error
+ */
+function expectLastElement<Selector extends string, Selected extends Element = ParseSelector<Selector, HTMLElement>>(
+	selectors: Selector | readonly Selector[],
+	baseElement?: ParentNode
+): Selected;
+function expectLastElement<Selected extends Element = HTMLElement>(
+	selectors: string | readonly string[],
+	baseElement?: ParentNode
+): Selected;
+function expectLastElement<Selected extends Element>(
+	selectors: string | readonly string[],
+	baseElement?: ParentNode,
+): Selected {
+	// Shortcut with specified-but-null baseElements
+	if (arguments.length === 2 && !baseElement) {
+		throw new ElementNotFoundError('Expected element not found because the base is specified but null');
+	}
+
+	const all = (baseElement ?? document).querySelectorAll<Selected>(String(selectors));
+	if (all.length > 0) {
+		// eslint-disable-next-line unicorn/prefer-at -- Not an Array, not worth converting it
+		return all[all.length - 1]!;
+	}
+
+	throw new ElementNotFoundError(`Expected elements not found: ${String(selectors)}`);
+}
+
+export {$, $$, lastElement, elementExists, expectElement, expectElements, expectLastElement, countElements};

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ $$('.foo', [baseElement1, baseElement2]);
 The strict export will throw an error if the element is not found, instead of returning `undefined`. This is also reflected in the types, which are non-nullable:
 
 ```ts
-import {$, $optional, $$, $$optional} from 'select-dom/strict.js';
+import {$, $optional, $$, $$optional, lastElement, lastElementOptional} from 'select-dom/strict.js';
 
 const must: HTMLAnchorElement = $('.foo a[href=bar]'); //
 const optional: HTMLAnchorElement | undefined = $optional('.foo a[href=bar]');
@@ -94,6 +94,10 @@ const optional: HTMLAnchorElement | undefined = $optional('.foo a[href=bar]');
 
 const oneOrMore: HTMLAnchorElement[] = $$('.foo a[href=bar]'); //
 const zeroOrMore: HTMLAnchorElement[] = $$optional('.foo a[href=bar]');
+
+
+const last: HTMLAnchorElement = lastElement('.foo a[href=bar]');
+const lastOptional: HTMLAnchorElement | undefined = lastElementOptional('.foo a[href=bar]');
 ```
 
 ## Related

--- a/strict.ts
+++ b/strict.ts
@@ -1,8 +1,9 @@
 export {
 	$ as $optional,
 	$$ as $$optional,
+	lastElement as lastElementOptional,
+
 	expectElement as $,
 	expectElements as $$,
 	expectLastElement as lastElement,
-	lastElement as lastElementOptional,
 } from './index.js';

--- a/strict.ts
+++ b/strict.ts
@@ -3,4 +3,6 @@ export {
 	$$ as $$optional,
 	expectElement as $,
 	expectElements as $$,
+	expectLastElement as lastElement,
+	lastElement as lastElementOptional,
 } from './index.js';

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import {$, $$, lastElement, elementExists, expectElement, ElementNotFoundError} from './index.js';
+import {$, $$, lastElement, elementExists, expectElement, expectLastElement, ElementNotFoundError} from './index.js';
 
 document.body.innerHTML = `
 	<ul>
@@ -57,6 +57,24 @@ test('selects the last element within an ancestor', t => {
 
 	const li = [...document.querySelectorAll('ul li')].pop();
 	t.equal(lastElement('li', lastElement('ul')), li);
+});
+
+test('expects a last element', t => {
+	t.plan(2);
+
+	const li = [...document.querySelectorAll('ul li')].pop();
+	t.equal(expectLastElement('ul li'), li);
+
+	t.throws(() => expectLastElement('lololol'));
+});
+
+test('expects a last element within an ancestor', t => {
+	t.plan(2);
+
+	const li = [...document.querySelectorAll('ul li')].pop();
+	t.equal(expectLastElement('li', expectLastElement('ul')), li);
+
+	t.throws(() => expectLastElement('ul', expectLastElement('li')), error => error instanceof ElementNotFoundError);
 });
 
 test('tests existence of one element', t => {


### PR DESCRIPTION
I don't call `expectElements` internally because the error message for this function is slightly different, and it would mean we are repeating the short circuit test. In the future, it would be possible to easily call `expectElements` internally if the arguments are checked more "properly", without `arguments.length === 2 && !baseElement`.

Fixes #34